### PR TITLE
Issue #5: Test global gitconfig for errors

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# tests --- run static tests against this repository
+# run_tests.sh --- run static tests against this repository
 # Mike Barker <mike@thebarkers.com>
 # March 14th 2019
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# tests --- run static tests against this repository
+# Mike Barker <mike@thebarkers.com>
+# March 14th 2019
+
+shellcheck {install,run_tests.sh}
+
+# Listing the configuration will fail if there are format errors in the gitconfig file
+# It does not check for valid settings, just valid formating.
+git --no-pager config -f ./home/.gitconfig -l > /dev/null
+

--- a/tests
+++ b/tests
@@ -1,6 +1,0 @@
-#!/bin/bash
-# tests --- run static tests against this repository
-# Mike Barker <mike@thebarkers.com>
-# March 14th 2019
-
-shellcheck {install,tests}


### PR DESCRIPTION
I renamed the tests bash script to run_tests.sh
and added a check that the global .gitconfig file does not have a syntax error.