### PR TITLE
19 platform specific settings

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -47,9 +47,12 @@
 	defaultBranch = main
 
 # Include OS specific configuration
-[includeIf "gitdir:%(prefix)//Users"]
-    path = ~/.gitconfig-macos
+[incldueIf "gitdir:%(prefix)//home/"]
+    path = ~/.gitconfig-linux
 
-[includeIf "gitdir:C:"]
+[includeIf "gitdir:%(prefix)//Users/"]
+    path = ~/.gitconfig-darwin
+
+[includeIf "gitdir:C:/"]
     path = ~/.gitconfig-windows
 

--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -41,10 +41,15 @@
 [hub]
 	protocol = https
 
-[credential]
-    helper = "!f() { if [ \"$(uname -s)\" = Darwin ]; then git credential-osxkeychain \"$@\"; else git credential-cache --timeout 3600 \"$@\"; fi; };f"
-
 [pull]
     ff = only
 [init]
 	defaultBranch = main
+
+# Include OS specific configuration
+[includeIf "gitdir:%(prefix)//Users"]
+    path = ~/.gitconfig-macos
+
+[includeIf "gitdir:C:"]
+    path = ~/.gitconfig-windows
+

--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -47,7 +47,7 @@
 	defaultBranch = main
 
 # Include OS specific configuration
-[incldueIf "gitdir:%(prefix)//home/"]
+[includeIf "gitdir:%(prefix)//home/"]
     path = ~/.gitconfig-linux
 
 [includeIf "gitdir:%(prefix)//Users/"]

--- a/home/.gitconfig-darwin
+++ b/home/.gitconfig-darwin
@@ -1,0 +1,2 @@
+[credential]
+    helper = osxkeychain

--- a/home/.gitconfig-linux
+++ b/home/.gitconfig-linux
@@ -1,0 +1,3 @@
+[credential]
+    helper = cache
+

--- a/home/.gitconfig-windows
+++ b/home/.gitconfig-windows
@@ -1,0 +1,3 @@
+[credential]
+    helper = manager
+

--- a/home/.gitconfig-windows
+++ b/home/.gitconfig-windows
@@ -1,3 +1,5 @@
+[core]
+    sshCommand = C:/Windows/System32/OpenSSH/ssh.exe
 [credential]
     helper = manager
 


### PR DESCRIPTION
Added `includeIf` directives to load system specific settings.
Moved credential settings into `.gitconfig-[darwin, linux, or windows] file.

Close #19 