### PR TITLE
Fix includeIf on windows

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -53,6 +53,6 @@
 [includeIf "gitdir:%(prefix)//Users/"]
     path = ~/.gitconfig-darwin
 
-[includeIf "gitdir:C:/"]
+[includeIf "gitdir/i:C:/Users/mike/"]
     path = ~/.gitconfig-windows
 


### PR DESCRIPTION
I needed to add /i to the gitdir parameter so the
search would be case insensitive